### PR TITLE
Temporarily convert to pcl 

### DIFF
--- a/open3d_conversions/CMakeLists.txt
+++ b/open3d_conversions/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(open3d_vendor REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(pcl_conversions REQUIRED)
 
 include_directories(
   include
@@ -31,6 +32,7 @@ ament_target_dependencies(
   "rclcpp"
   "rcpputils"
   "sensor_msgs"
+  "pcl_conversions"
 )
 target_link_libraries(open3d_conversions ${Open3D_LIBRARIES})
 target_compile_definitions(open3d_conversions PUBLIC "OPEN3D_CONVERSIONS_BUILDING_LIBRARY")

--- a/open3d_conversions/CMakeLists.txt
+++ b/open3d_conversions/CMakeLists.txt
@@ -7,15 +7,9 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 # system dependencies
-find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_ros REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
 find_package(Eigen3 REQUIRED)
-
-find_package(open3d_vendor REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rcpputils REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(pcl_conversions REQUIRED)
+ament_auto_find_build_dependencies()
 
 include_directories(
   include
@@ -23,44 +17,20 @@ include_directories(
   ${Open3D_INCLUDE_DIRS}
 )
 
-add_library(open3d_conversions src/open3d_conversions.cpp)
-target_include_directories(open3d_conversions PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
-ament_target_dependencies(
-  open3d_conversions
-  "rclcpp"
-  "rcpputils"
-  "sensor_msgs"
-  "pcl_conversions"
-)
+ament_auto_add_library(open3d_conversions src/open3d_conversions.cpp)
 target_link_libraries(open3d_conversions ${Open3D_LIBRARIES})
 target_compile_definitions(open3d_conversions PUBLIC "OPEN3D_CONVERSIONS_BUILDING_LIBRARY")
-
-install(
-  DIRECTORY include/
-  DESTINATION include
-)
-install(
-  TARGETS open3d_conversions
-  EXPORT export_${PROJECT_NAME}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
-)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_add_gtest(test_open3d_conversions test/test_open3d_conversions.cpp)
-  target_link_libraries(test_open3d_conversions open3d_conversions ${Open3D_LIBRARIES})
+  target_link_libraries(
+    test_open3d_conversions
+    open3d_conversions
+    ${Open3D_LIBRARIES}
+  )
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_include_directories(include)
-ament_export_libraries(open3d_conversions)
-ament_export_targets(export_${PROJECT_NAME})
-ament_export_dependencies(Open3D rclcpp)
-
-ament_package()
+ament_auto_package()

--- a/open3d_conversions/package.xml
+++ b/open3d_conversions/package.xml
@@ -13,7 +13,7 @@
 
   <author email="matnay17@gmail.com">Pranay Mathur</author>
   <author email="nkhedekar@nevada.unr.edu">Nikhil Khedekar</author>
-  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>open3d_vendor</depend>
   <depend>rclcpp</depend>

--- a/open3d_conversions/package.xml
+++ b/open3d_conversions/package.xml
@@ -20,6 +20,7 @@
   <depend>rcpputils</depend>
   <depend>sensor_msgs</depend>
   <depend>eigen</depend>
+  <depend>pcl_conversions</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>

--- a/open3d_conversions/src/open3d_conversions.cpp
+++ b/open3d_conversions/src/open3d_conversions.cpp
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 // C++
-#include <memory>
-#include <string>
-#include <sstream>
+#include "open3d_conversions/open3d_conversions.hpp"
+
+#include <pcl_conversions/pcl_conversions.h>
 
 #include <rcpputils/endian.hpp>
 #include <sensor_msgs/image_encodings.hpp>
-#include "open3d_conversions/open3d_conversions.hpp"
+#include <sstream>
+#include <string>
 
 // Verify that an encoding makes sense with a given image
 static void checkEncodingValidity(
@@ -133,11 +134,6 @@ void rosToOpen3d(
   const sensor_msgs::msg::PointCloud2::SharedPtr & ros_pc2,
   open3d::geometry::PointCloud & o3d_pc, bool skip_colors)
 {
-  sensor_msgs::PointCloud2ConstIterator<float> ros_pc2_x(*ros_pc2, "x");
-  sensor_msgs::PointCloud2ConstIterator<float> ros_pc2_y(*ros_pc2, "y");
-  sensor_msgs::PointCloud2ConstIterator<float> ros_pc2_z(*ros_pc2, "z");
-  o3d_pc.points_.reserve(ros_pc2->height * ros_pc2->width);
-
   // Check if color fields exist
   bool has_rgb = false;
   bool has_intensity = false;
@@ -150,33 +146,34 @@ void rosToOpen3d(
     }
   }
   if (ros_pc2->fields.size() == 3 || skip_colors) {
-    for (size_t i = 0; ros_pc2_x != ros_pc2_x.end() && ros_pc2_y != ros_pc2_y.end() && ros_pc2_z != ros_pc2_z.end();
-         ++i, ++ros_pc2_x, ++ros_pc2_y, ++ros_pc2_z) {
-      o3d_pc.points_.emplace_back(*ros_pc2_x, *ros_pc2_y, *ros_pc2_z);
+    pcl::PointCloud<pcl::PointXYZ> pcl_pc;
+    pcl::fromROSMsg(*ros_pc2, pcl_pc);
+    o3d_pc.points_.reserve(pcl_pc.points.size());
+    for (const auto & point : pcl_pc.points) {
+      o3d_pc.points_.emplace_back(point.x, point.y, point.z);
     }
   } else {
-    o3d_pc.colors_.reserve(ros_pc2->height * ros_pc2->width);
     if (has_rgb) {
-      sensor_msgs::PointCloud2ConstIterator<float> ros_pc2_rgb(*ros_pc2, "rgb");
-      for (size_t i = 0; ros_pc2_x != ros_pc2_x.end() &&
-           ros_pc2_y != ros_pc2_y.end() && ros_pc2_z != ros_pc2_z.end() &&
-           ros_pc2_rgb != ros_pc2_rgb.end();
-           ++i, ++ros_pc2_x, ++ros_pc2_y, ++ros_pc2_z, ++ros_pc2_rgb) {
-        o3d_pc.points_.emplace_back(*ros_pc2_x, *ros_pc2_y, *ros_pc2_z);
-        uint32_t rgb = *reinterpret_cast<const uint32_t *>(&(*ros_pc2_rgb));
+      pcl::PointCloud<pcl::PointXYZRGB> pcl_pc;
+      pcl::fromROSMsg(*ros_pc2, pcl_pc);
+      o3d_pc.points_.reserve(pcl_pc.points.size());
+      o3d_pc.colors_.reserve(pcl_pc.points.size());
+      for (const auto & point : pcl_pc.points) {
+        o3d_pc.points_.emplace_back(point.x, point.y, point.z);
+        uint32_t rgb = point.rgb;
         uint8_t r = (rgb >> 16) & 0x0000FF;
         uint8_t g = (rgb >> 8) & 0x0000FF;
         uint8_t b = rgb & 0x0000FF;
         o3d_pc.colors_.emplace_back(r / 255.0, g / 255.0, b / 255.0);
       }
     } else if (has_intensity) {
-      sensor_msgs::PointCloud2ConstIterator<float> ros_pc2_i(*ros_pc2, "intensity");
-      for (size_t i = 0; ros_pc2_x != ros_pc2_x.end() &&
-           ros_pc2_y != ros_pc2_y.end() && ros_pc2_z != ros_pc2_z.end() &&
-           ros_pc2_i != ros_pc2_i.end();
-           ++i, ++ros_pc2_x, ++ros_pc2_y, ++ros_pc2_z, ++ros_pc2_i) {
-        o3d_pc.points_.emplace_back(*ros_pc2_x, *ros_pc2_y, *ros_pc2_z);
-        float intensity = *ros_pc2_i;
+      pcl::PointCloud<pcl::PointXYZI> pcl_pc;
+      pcl::fromROSMsg(*ros_pc2, pcl_pc);
+      o3d_pc.points_.reserve(pcl_pc.points.size());
+      o3d_pc.colors_.reserve(pcl_pc.points.size());
+      for (const auto & point : pcl_pc.points) {
+        o3d_pc.points_.emplace_back(point.x, point.y, point.z);
+        float intensity = point.intensity;
         o3d_pc.colors_.emplace_back(intensity, intensity, intensity);
       }
     }


### PR DESCRIPTION
`sensor_msgs::PointCloud2ConstIterator` の実績があまりないので、
効率は下がるが、一時的に信頼性のある`pcl::fromROSMsg()`でpclのpoint cloudに変換してから、
open3dに変換する